### PR TITLE
Better apt upgrade command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Jonathan Rhodes <jonathan.rhodes@sitback.com.au>
 
 # update repositories
 RUN apt-get -y update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade
 
 # Update /usr/sbin/policy-rc.d
 COPY ./root/policy-rc.d /usr/sbin/policy-rc.d


### PR DESCRIPTION
Changed apt-get upgrade command to the safer dist-upgrade to prevent possible problems.

```
dist-upgrade
dist-upgrade in addition to performing the function of upgrade,
also intelligently handles changing dependencies with new versions
of packages; apt-get has a "smart" conflict resolution system, and
it will attempt to upgrade the most important packages at the
expense of less important ones if necessary. So, dist-upgrade
command may remove some packages. The /etc/apt/sources.list file
contains a list of locations from which to retrieve desired package
files. See also apt_preferences(5) for a mechanism for overriding
the general settings for individual packages.
```
